### PR TITLE
add prefab support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,18 @@ if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"
 }
 
+task prepareHeaders1(type: Copy) {
+  from fileTree('../cpp').filter { it.isFile() }
+  into "${project.buildDir}/headers/rnworklets/"
+  includeEmptyDirs = false
+}
+
+task prepareHeaders2(type: Copy) {
+  from fileTree('../cpp').filter { it.isFile() }
+  into "${project.buildDir}/headers/rnworklets/rnworklets"
+  includeEmptyDirs = false
+}
+
 android {
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
@@ -139,6 +151,16 @@ android {
       "**/libjscexecutor.so",
     ]
   }
+  
+  buildFeatures {
+    prefabPublishing true
+  }
+
+  prefab {
+    rnworklets {
+      headers "${project.buildDir}/headers/rnworklets/"
+    }
+  }
 }
 
 dependencies {
@@ -147,3 +169,5 @@ dependencies {
     implementation "com.facebook.react:hermes-android"
   }
 }
+
+preBuild.dependsOn("prepareHeaders1", "prepareHeaders2")


### PR DESCRIPTION
How to consume in a target app:

CMakeList.txt:

```
find_package(react-native-worklets REQUIRED CONFIG)

target_link_libraries(
  ${PACKAGE_NAME}
  react-native-worklets::rnworklets
```

How to include header:
```c++
#include <rnworklets/JsiBaseDecorator.h>
#include <rnworklets/JsiWorkletContext.h>
```


**It needs to be tested on a fresh app!!**