### PR TITLE
fix: Wrap values in closure in `_closure` object

### DIFF
--- a/cpp/JsiWorklet.h
+++ b/cpp/JsiWorklet.h
@@ -24,7 +24,7 @@ namespace jsi = facebook::jsi;
  */
 class JsThisWrapper {
 public:
-  JsThisWrapper(jsi::Runtime &runtime, const jsi::Value &thisValue) {
+  JsThisWrapper(jsi::Runtime &runtime, const jsi::Object &thisValue) {
     _oldThis = runtime.global().getProperty(runtime, PropNameJsThis);
     runtime.global().setProperty(runtime, PropNameJsThis, thisValue);
     _runtime = &runtime;
@@ -182,7 +182,9 @@ public:
     jsi::Value retVal;
 
     // Prepare jsThis
-    JsThisWrapper thisWrapper(runtime, unwrappedClosure);
+    jsi::Object closureObject(runtime);
+    closureObject.setProperty(runtime, "_closure", unwrappedClosure);
+    JsThisWrapper thisWrapper(runtime, closureObject);
 
     // Call the unwrapped function
     if (!thisValue.isObject()) {


### PR DESCRIPTION
This is how the REA plugin works, all values in the closure are in `jsThis._closure`. Right now, RN Worklets put everything in `jsThis`. No `_closure` object.