### PR TITLE
fix: Make `install` blocking & synchronous to run on JS Thread

### DIFF
--- a/android/src/main/java/com/worklets/WorkletsModule.java
+++ b/android/src/main/java/com/worklets/WorkletsModule.java
@@ -35,7 +35,7 @@ public class WorkletsModule extends com.worklets.WorkletsSpec {
 
   public static native boolean nativeInstall(long jsiRuntimeRef, CallInvokerHolder jsCallInvokerHolder);
 
-  @ReactMethod
+  @ReactMethod(isBlockingSynchronousMethod = true)
   public boolean install() {
     try {
       ReactApplicationContext context = weakReactContext.get();


### PR DESCRIPTION
If this isn't blocking & synchronous, it runs on a background Thread. It is not safe to access the JSI Runtime on the background Thread, so this crashes with a SIG_ABRT otherwise