### PR TITLE
fix: Use `pthread_threadid_np` to get current Thread ID

### DIFF
--- a/cpp/JsiWorkletContext.h
+++ b/cpp/JsiWorkletContext.h
@@ -249,8 +249,8 @@ private:
   std::function<void(std::function<void()> &&)> _jsCallInvoker;
   std::function<void(std::function<void()> &&)> _workletCallInvoker;
   size_t _contextId;
-  uint64_t _threadId;
-  uint64_t _jsThreadId;
+  thread_id_t _threadId;
+  thread_id_t _jsThreadId;
 
   static std::vector<std::shared_ptr<JsiBaseDecorator>> decorators;
   static std::shared_ptr<JsiWorkletContext> defaultInstance;

--- a/cpp/JsiWorkletContext.h
+++ b/cpp/JsiWorkletContext.h
@@ -241,7 +241,7 @@ private:
   /**
    Returns the ID of the current calling Thread.
   */
-  thread_id_t getCurrentThreadId();
+  static thread_id_t getCurrentThreadId();
 
   jsi::Runtime *_jsRuntime;
   std::unique_ptr<jsi::Runtime> _workletRuntime;

--- a/cpp/JsiWorkletContext.h
+++ b/cpp/JsiWorkletContext.h
@@ -91,7 +91,7 @@ public:
    JS thread (or any other invalid context thread) nullptr is returned.
    */
   static JsiWorkletContext *getCurrent() {
-    auto id = std::this_thread::get_id();
+    auto id = getCurrentThreadId();
     if (threadContexts.count(id) != 0) {
       return threadContexts.at(id);
     }
@@ -230,18 +230,23 @@ private:
   void applyDecorators(
       const std::vector<std::shared_ptr<JsiBaseDecorator>> &decorators);
 
+  /**
+   Returns the ID of the current calling Thread.
+  */
+  uint64_t getCurrentThreadId();
+
   jsi::Runtime *_jsRuntime;
   std::unique_ptr<jsi::Runtime> _workletRuntime;
   std::string _name;
   std::function<void(std::function<void()> &&)> _jsCallInvoker;
   std::function<void(std::function<void()> &&)> _workletCallInvoker;
   size_t _contextId;
-  std::thread::id _threadId;
-  std::thread::id _jsThreadId;
+  uint64_t _threadId;
+  uint64_t _jsThreadId;
 
   static std::vector<std::shared_ptr<JsiBaseDecorator>> decorators;
   static std::shared_ptr<JsiWorkletContext> defaultInstance;
-  static std::map<std::thread::id, JsiWorkletContext *> threadContexts;
+  static std::map<uint64_t, JsiWorkletContext *> threadContexts;
   static size_t contextIdNumber;
 };
 

--- a/cpp/JsiWorkletContext.h
+++ b/cpp/JsiWorkletContext.h
@@ -14,6 +14,14 @@
 
 #include <jsi/jsi.h>
 
+#ifdef __APPLE__
+#include <pthread/pthread.h>
+typedef uint64_t thread_id_t;
+#else
+#include <thread>
+typedef std::thread::id thread_id_t;
+#endif
+
 namespace RNWorklet {
 
 namespace jsi = facebook::jsi;
@@ -233,7 +241,7 @@ private:
   /**
    Returns the ID of the current calling Thread.
   */
-  uint64_t getCurrentThreadId();
+  thread_id_t getCurrentThreadId();
 
   jsi::Runtime *_jsRuntime;
   std::unique_ptr<jsi::Runtime> _workletRuntime;
@@ -246,7 +254,7 @@ private:
 
   static std::vector<std::shared_ptr<JsiBaseDecorator>> decorators;
   static std::shared_ptr<JsiWorkletContext> defaultInstance;
-  static std::map<uint64_t, JsiWorkletContext *> threadContexts;
+  static std::map<thread_id_t, JsiWorkletContext *> threadContexts;
   static size_t contextIdNumber;
 };
 


### PR DESCRIPTION
On iOS, we use `pthread_threadid_np` to get the current Thread ID. On Android, this still uses this_thread::get_id().