### PR TITLE
Changed getCurrent api to map context on runtime pointer instead of thread id.

### DIFF
--- a/cpp/JsiWorklet.h
+++ b/cpp/JsiWorklet.h
@@ -367,7 +367,7 @@ public:
                   const jsi::Value *arguments, size_t count) {
     if (_workletFunction == nullptr) {
       _workletFunction = _worklet->createWorkletJsFunction(runtime);
-      auto owningContext = JsiWorkletContext::getCurrent();
+      auto owningContext = JsiWorkletContext::getCurrent(runtime);
       if (owningContext) {
         _owningContext = owningContext->shared_from_this();
       } else {

--- a/cpp/JsiWorklet.h
+++ b/cpp/JsiWorklet.h
@@ -223,8 +223,8 @@ public:
 
       // Call the unwrapped function
       if (thisValue.isObject()) {
-        return workletFunction->callWithThis(runtime, thisValue.asObject(runtime),
-                                             arguments, count);
+        return workletFunction->callWithThis(
+            runtime, thisValue.asObject(runtime), arguments, count);
       } else {
         return workletFunction->call(runtime, arguments, count);
       }

--- a/cpp/JsiWorkletApi.cpp
+++ b/cpp/JsiWorkletApi.cpp
@@ -8,9 +8,9 @@
 
 #include "JsiBaseDecorator.h"
 #include "JsiConsoleDecorator.h"
-#include "JsiPerformanceDecorator.h"
 #include "JsiHostObject.h"
 #include "JsiJsDecorator.h"
+#include "JsiPerformanceDecorator.h"
 #include "JsiSetImmediateDecorator.h"
 #include "JsiSharedValue.h"
 #include "JsiWorklet.h"
@@ -57,7 +57,8 @@ std::shared_ptr<JsiWorkletApi> JsiWorkletApi::getInstance() {
     JsiWorkletContext::addDecorator(
         std::make_shared<JsiPerformanceDecorator>());
 
-    // In JS for now: JsiWorkletContext::addDecorator(std::make_shared<JsiConsoleDecorator>());
+    // In JS for now:
+    // JsiWorkletContext::addDecorator(std::make_shared<JsiConsoleDecorator>());
   }
   return instance;
 }

--- a/cpp/JsiWorkletContext.cpp
+++ b/cpp/JsiWorkletContext.cpp
@@ -25,8 +25,7 @@ const char *GlobalPropertyName = "global";
 
 std::vector<std::shared_ptr<JsiBaseDecorator>> JsiWorkletContext::decorators;
 std::shared_ptr<JsiWorkletContext> JsiWorkletContext::defaultInstance;
-std::map<void*, JsiWorkletContext *>
-    JsiWorkletContext::runtimeMappings;
+std::map<void *, JsiWorkletContext *> JsiWorkletContext::runtimeMappings;
 size_t JsiWorkletContext::contextIdNumber = 1000;
 
 namespace jsi = facebook::jsi;
@@ -60,7 +59,7 @@ void JsiWorkletContext::initialize(
   _jsCallInvoker = jsCallInvoker;
   _workletCallInvoker = workletCallInvoker;
   _contextId = ++contextIdNumber;
-  
+
   _jsThreadId = std::this_thread::get_id();
   runtimeMappings.emplace(&_workletRuntime, this);
 }
@@ -286,8 +285,8 @@ JsiWorkletContext::createCallInContext(jsi::Runtime &runtime,
 
     // Now we are in a situation where we are calling cross context (js -> ctx,
     // ctx -> ctx, ctx -> js)
-    
-     // Ensure that the function is a worklet
+
+    // Ensure that the function is a worklet
     if (workletInvoker == nullptr && convention != CallingConvention::CtxToJs) {
       throw jsi::JSError(runtime, "In callInContext the function parameter "
                                   "is not a valid worklet and "
@@ -337,7 +336,8 @@ JsiWorkletContext::createCallInContext(jsi::Runtime &runtime,
                         std::shared_ptr<PromiseParameter> promise) {
           // Create callback wrapper
           callIntoCorrectContext([callback, workletInvoker, thisWrapper,
-                                  argsWrapper, promise, func](jsi::Runtime &runtime) {
+                                  argsWrapper, promise,
+                                  func](jsi::Runtime &runtime) {
             try {
 
               auto args = argsWrapper.getArguments(runtime);
@@ -345,12 +345,11 @@ JsiWorkletContext::createCallInContext(jsi::Runtime &runtime,
               jsi::Value result;
               if (workletInvoker != nullptr) {
                 result = workletInvoker->call(
-                      runtime, thisWrapper->unwrap(runtime),
-                      ArgumentsWrapper::toArgs(args), argsWrapper.getCount());
+                    runtime, thisWrapper->unwrap(runtime),
+                    ArgumentsWrapper::toArgs(args), argsWrapper.getCount());
               } else {
-                result = func->call(
-                       runtime,
-                       ArgumentsWrapper::toArgs(args), argsWrapper.getCount());
+                result = func->call(runtime, ArgumentsWrapper::toArgs(args),
+                                    argsWrapper.getCount());
               }
 
               auto retVal = JsiWrapper::wrap(runtime, result);

--- a/cpp/JsiWorkletContext.h
+++ b/cpp/JsiWorkletContext.h
@@ -90,8 +90,8 @@ public:
    Returns the worklet context for the current thread. If called from the
    JS thread (or any other invalid context thread) nullptr is returned.
    */
-  static JsiWorkletContext *getCurrent(jsi::Runtime& runtime) {
-    auto rtPtr = static_cast<void*>(&runtime);
+  static JsiWorkletContext *getCurrent(jsi::Runtime &runtime) {
+    auto rtPtr = static_cast<void *>(&runtime);
     if (runtimeMappings.count(rtPtr) != 0) {
       return runtimeMappings.at(rtPtr);
     }
@@ -235,12 +235,12 @@ private:
   std::string _name;
   std::function<void(std::function<void()> &&)> _jsCallInvoker;
   std::function<void(std::function<void()> &&)> _workletCallInvoker;
-  size_t _contextId;  
+  size_t _contextId;
   std::thread::id _jsThreadId;
 
   static std::vector<std::shared_ptr<JsiBaseDecorator>> decorators;
   static std::shared_ptr<JsiWorkletContext> defaultInstance;
-  static std::map<void*, JsiWorkletContext *> runtimeMappings;
+  static std::map<void *, JsiWorkletContext *> runtimeMappings;
   static size_t contextIdNumber;
 };
 

--- a/cpp/JsiWorkletContext.h
+++ b/cpp/JsiWorkletContext.h
@@ -90,10 +90,10 @@ public:
    Returns the worklet context for the current thread. If called from the
    JS thread (or any other invalid context thread) nullptr is returned.
    */
-  static JsiWorkletContext *getCurrent() {
-    auto id = std::this_thread::get_id();
-    if (threadContexts.count(id) != 0) {
-      return threadContexts.at(id);
+  static JsiWorkletContext *getCurrent(jsi::Runtime& runtime) {
+    auto rtPtr = static_cast<void*>(&runtime);
+    if (runtimeMappings.count(rtPtr) != 0) {
+      return runtimeMappings.at(rtPtr);
     }
     return nullptr;
   }
@@ -202,7 +202,7 @@ public:
    */
   static void verifyRuntime(jsi::Runtime &runtime) {
 #if DEBUG
-    auto ctx = JsiWorkletContext::getCurrent();
+    auto ctx = JsiWorkletContext::getCurrent(runtime);
     if (ctx) {
       assert(&ctx->getWorkletRuntime() == &runtime &&
              "Worklet runtime is not the same as the provided runtime");
@@ -235,13 +235,12 @@ private:
   std::string _name;
   std::function<void(std::function<void()> &&)> _jsCallInvoker;
   std::function<void(std::function<void()> &&)> _workletCallInvoker;
-  size_t _contextId;
-  std::thread::id _threadId;
+  size_t _contextId;  
   std::thread::id _jsThreadId;
 
   static std::vector<std::shared_ptr<JsiBaseDecorator>> decorators;
   static std::shared_ptr<JsiWorkletContext> defaultInstance;
-  static std::map<std::thread::id, JsiWorkletContext *> threadContexts;
+  static std::map<void*, JsiWorkletContext *> runtimeMappings;
   static size_t contextIdNumber;
 };
 

--- a/cpp/decorators/JsiPerformanceDecorator.h
+++ b/cpp/decorators/JsiPerformanceDecorator.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
-#include <chrono>
 
 #include "JsiBaseDecorator.h"
 #include "JsiHostObject.h"
@@ -43,4 +43,3 @@ public:
   };
 };
 } // namespace RNWorklet
-

--- a/cpp/decorators/JsiSetImmediateDecorator.h
+++ b/cpp/decorators/JsiSetImmediateDecorator.h
@@ -76,7 +76,7 @@ public:
             }
           };
 
-          auto context = JsiWorkletContext::getCurrent();
+          auto context = JsiWorkletContext::getCurrent(runtime);
           if (context) {
             // Invoke function on context thread / runtime
             context->invokeOnWorkletThread(

--- a/cpp/wrappers/JsiPromiseWrapper.cpp
+++ b/cpp/wrappers/JsiPromiseWrapper.cpp
@@ -210,7 +210,7 @@ void JsiPromiseWrapper::setValue(jsi::Runtime &runtime,
 
   auto obj = value.asObject(runtime);
 
-  auto callingContext = JsiWorkletContext::getCurrent();
+  auto callingContext = JsiWorkletContext::getCurrent(runtime);
 
   auto maybeThenFunc = obj.getProperty(runtime, ThenPropName);
   if (!maybeThenFunc.isObject() ||


### PR DESCRIPTION
Api now takes runtime as parameter and maps runtime with context instead of mapping on thread id.