### PR TITLE
Fixed wrong emplace in mapping emplace

### DIFF
--- a/cpp/JsiWorkletContext.cpp
+++ b/cpp/JsiWorkletContext.cpp
@@ -61,7 +61,7 @@ void JsiWorkletContext::initialize(
   _contextId = ++contextIdNumber;
 
   _jsThreadId = std::this_thread::get_id();
-  runtimeMappings.emplace(&_workletRuntime, this);
+  runtimeMappings.emplace(&getWorkletRuntime(), this);
 }
 
 void JsiWorkletContext::initialize(


### PR DESCRIPTION
We need to call getWorkletRuntime() to ensure that the runtime as been created. Without this we just added a random pointer value to the map - this PR fixes this.