### PR TITLE
fix: Updated support for nested plugins

### DIFF
--- a/src/plugin/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/plugin/__tests__/__snapshots__/index.spec.js.snap
@@ -54,8 +54,8 @@ exports[`babel plugin doesn't transform standard callback functions 1`] = `
 `;
 
 exports[`babel plugin doesn't transform string literals 1`] = `
-"var _worklet_9810417751380_init_data = {
-  code: \\"function foo(x){const bar='worklet';const baz=\\\\\\"worklet\\\\\\";}\\",
+"var _worklet_7442778059540_init_data = {
+  code: \\"function foo(x){var bar='worklet';var baz=\\\\\\"worklet\\\\\\";}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
@@ -65,8 +65,8 @@ var foo = function () {
     var baz = \\"worklet\\";
   };
   _f._closure = {};
-  _f.__initData = _worklet_9810417751380_init_data;
-  _f.__workletHash = 9810417751380;
+  _f.__initData = _worklet_7442778059540_init_data;
+  _f.__workletHash = 7442778059540;
   _f.__stackDetails = _e;
   return _f;
 }();"
@@ -121,8 +121,8 @@ function App() {
 `;
 
 exports[`babel plugin supports SequenceExpression, with worklet closure 1`] = `
-"var _worklet_16676723780973_init_data = {
-  code: \\"function onStart(){const{obj}=this._closure;const a=obj.a;}\\",
+"var _worklet_5237526540557_init_data = {
+  code: \\"function onStart(){const{obj}=this._closure;var a=obj.a;}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 function App() {
@@ -141,13 +141,48 @@ function App() {
           a: obj.a
         }
       };
-      _f.__initData = _worklet_16676723780973_init_data;
-      _f.__workletHash = 16676723780973;
+      _f.__initData = _worklet_5237526540557_init_data;
+      _f.__workletHash = 5237526540557;
       _f.__stackDetails = _e;
       return _f;
     }()
   }, []);
 }"
+`;
+
+exports[`babel plugin supports nested worklets keeping worklet decoration for inner worklet 1`] = `
+"var _worklet_16463389415794_init_data = {
+  code: \\"function anonymous(){return 200;}\\",
+  location: \\"${ process.cwd() }/jest tests fixture\\"
+};
+var _worklet_7858844471746_init_data = {
+  code: \\"function anonymous(){const{_worklet_16463389415794_init_data}=this._closure;var b=function(){var _e=[new Error(),1,-20];var _f=function _f(){return 200;};_f._closure={};_f.__initData=_worklet_16463389415794_init_data;_f.__workletHash=16463389415794;_f.__stackDetails=_e;return _f;}();return 100+b();}\\",
+  location: \\"${ process.cwd() }/jest tests fixture\\"
+};
+var f = function () {
+  var _e = [new Error(), -2, -20];
+  var _f = function _f() {
+    var b = function () {
+      var _e = [new Error(), 1, -20];
+      var _f = function _f() {
+        return 200;
+      };
+      _f._closure = {};
+      _f.__initData = _worklet_16463389415794_init_data;
+      _f.__workletHash = 16463389415794;
+      _f.__stackDetails = _e;
+      return _f;
+    }();
+    return 100 + b();
+  };
+  _f._closure = {
+    _worklet_16463389415794_init_data: _worklet_16463389415794_init_data
+  };
+  _f.__initData = _worklet_7858844471746_init_data;
+  _f.__workletHash = 7858844471746;
+  _f.__stackDetails = _e;
+  return _f;
+}();"
 `;
 
 exports[`babel plugin supports recursive calls 1`] = `
@@ -201,8 +236,8 @@ function Box() {
 `;
 
 exports[`babel plugin transforms spread operator in worklets for arrays 1`] = `
-"var _worklet_3161057533258_init_data = {
-  code: \\"function foo(){const bar=[4,5];const baz=[1,...[2,3],...bar];}\\",
+"var _worklet_8509370056349_init_data = {
+  code: \\"function foo(){var bar=[4,5];var baz=[1].concat([2,3],bar);}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
@@ -212,16 +247,16 @@ var foo = function () {
     var baz = [1].concat([2, 3], bar);
   };
   _f._closure = {};
-  _f.__initData = _worklet_3161057533258_init_data;
-  _f.__workletHash = 3161057533258;
+  _f.__initData = _worklet_8509370056349_init_data;
+  _f.__workletHash = 8509370056349;
   _f.__stackDetails = _e;
   return _f;
 }();"
 `;
 
 exports[`babel plugin transforms spread operator in worklets for function arguments 1`] = `
-"var _worklet_9866931756941_init_data = {
-  code: \\"function foo(...args){console.log(args);}\\",
+"var _worklet_14198358014380_init_data = {
+  code: \\"function foo(){for(var _len=arguments.length,args=new Array(_len),_key=0;_key<_len;_key++){args[_key]=arguments[_key];}console.log(args);}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
@@ -233,8 +268,8 @@ var foo = function () {
     console.log(args);
   };
   _f._closure = {};
-  _f.__initData = _worklet_9866931756941_init_data;
-  _f.__workletHash = 9866931756941;
+  _f.__initData = _worklet_14198358014380_init_data;
+  _f.__workletHash = 14198358014380;
   _f.__stackDetails = _e;
   return _f;
 }();"
@@ -243,27 +278,29 @@ var foo = function () {
 exports[`babel plugin transforms spread operator in worklets for function calls 1`] = `
 "var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 var _toConsumableArray2 = _interopRequireDefault(require(\\"@babel/runtime/helpers/toConsumableArray\\"));
-var _worklet_2015887751437_init_data = {
-  code: \\"function foo(arg){console.log(...arg);}\\",
+var _worklet_4972199179357_init_data = {
+  code: \\"function foo(arg){const{_toConsumableArray}=this._closure;var _console;(_console=console).log.apply(_console,_toConsumableArray(arg));}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new Error(), -2, -20];
   var _f = function _f(arg) {
     var _console;
     (_console = console).log.apply(_console, (0, _toConsumableArray2.default)(arg));
   };
-  _f._closure = {};
-  _f.__initData = _worklet_2015887751437_init_data;
-  _f.__workletHash = 2015887751437;
+  _f._closure = {
+    _toConsumableArray: _toConsumableArray2.default
+  };
+  _f.__initData = _worklet_4972199179357_init_data;
+  _f.__workletHash = 4972199179357;
   _f.__stackDetails = _e;
   return _f;
 }();"
 `;
 
 exports[`babel plugin transforms spread operator in worklets for objects 1`] = `
-"var _worklet_792186851025_init_data = {
-  code: \\"function foo(){const bar={d:4,e:5};const baz={a:1,...{b:2,c:3},...bar};}\\",
+"var _worklet_12506920427210_init_data = {
+  code: \\"function foo(){var bar={d:4,e:5};var baz=Object.assign({a:1},{b:2,c:3},bar);}\\",
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
@@ -281,8 +318,8 @@ var foo = function () {
     }, bar);
   };
   _f._closure = {};
-  _f.__initData = _worklet_792186851025_init_data;
-  _f.__workletHash = 792186851025;
+  _f.__initData = _worklet_12506920427210_init_data;
+  _f.__workletHash = 12506920427210;
   _f.__stackDetails = _e;
   return _f;
 }();"

--- a/src/plugin/__tests__/index.spec.js
+++ b/src/plugin/__tests__/index.spec.js
@@ -378,4 +378,18 @@ describe("babel plugin", () => {
     const { code } = runPlugin(input);
     expect(code).toMatchSnapshot();
   });
+  it("supports nested worklets keeping worklet decoration for inner worklet", () => {
+    const input = `const f = () => {
+      "worklet";
+    
+      const b = () => {
+        "worklet";
+        return 200;
+      }
+    
+      return 100 + b();
+    }`;
+    const { code } = runPlugin(input);
+    expect(code).toMatchSnapshot();
+  });
 });

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -822,12 +822,12 @@ module.exports = function ({ types: t }) {
     },
     visitor: {
       "CallExpression": {
-        enter(path, state) {
+        exit(path, state) {
           processWorklets(t, path, state);
         },
       },
       "FunctionDeclaration|FunctionExpression|ArrowFunctionExpression": {
-        enter(path, state) {
+        exit(path, state) {
           processIfWorkletNode(t, path, state);
           processIfGestureHandlerEventCallbackFunctionNode(t, path, state);
         },


### PR DESCRIPTION
To avoid the problem with nested worklets loosing its code in the outer worklet's code definition, we changed the order of processing from using enter to exit in the plugin.

Added test and fixed plugin.