### PR TITLE
fix: create jni::ThreadScope on Android

### DIFF
--- a/cpp/JsiWorkletContext.cpp
+++ b/cpp/JsiWorkletContext.cpp
@@ -18,6 +18,10 @@
 
 #include <jsi/jsi.h>
 
+#ifdef ANDROID
+#include <fbjni/fbjni.h>
+#endif
+
 namespace RNWorklet {
 
 const char *WorkletRuntimeFlag = "__rn_worklets_runtime_flag";
@@ -132,6 +136,9 @@ void JsiWorkletContext::invokeOnWorkletThread(
   _workletCallInvoker([fp = std::move(fp), weakSelf = weak_from_this()]() {
     auto self = weakSelf.lock();
     if (self) {
+#ifdef ANDROID
+      facebook::jni::ThreadScope scope;
+#endif
       fp(self.get(), self->getWorkletRuntime());
     }
   });


### PR DESCRIPTION
The JNI ThreadScope is required to call into JNI on Android.

I'm not sure if it's a fair assumption that users always (or at least most of the time) want to use JNI, but I currently see no other way to declare that other than to create your own WorkletContext (which is a bit cumbersome and users probably wont figure this out otherwise)