### PR TITLE
fix: Promise state is now initialized to pending

### DIFF
--- a/cpp/wrappers/JsiPromiseWrapper.h
+++ b/cpp/wrappers/JsiPromiseWrapper.h
@@ -178,7 +178,7 @@ private:
   void propagateFulfilled(jsi::Runtime &runtime);
   void propagateRejected(jsi::Runtime &runtime);
 
-  PromiseState _state;
+  PromiseState _state = PromiseState::Pending;
   std::shared_ptr<JsiWrapper> _value;
   std::shared_ptr<JsiWrapper> _reason;
   std::vector<PromiseQueueItem> _thenQueue;


### PR DESCRIPTION
We had some issue on Android where the promise was not initialized correctly - this pr fixes this.