### PR TITLE
fix: cache hostfunctions on both runtime and cache

### DIFF
--- a/cpp/JsiWorkletContext.h
+++ b/cpp/JsiWorkletContext.h
@@ -54,13 +54,15 @@ public:
    Constructs a new worklet context using the given runtime and call invokers.
    @param name Name of the context
    @param jsRuntime The main JS Runtime
-   @param jsCallInvoker Callback for running a function on the main React JS Thread
+   @param jsCallInvoker Callback for running a function on the main React JS
+   Thread
    @param workletCallInvoker Callback for running a function on the worklet
    thread
    */
-  JsiWorkletContext(const std::string &name, jsi::Runtime *jsRuntime,
-                    std::function<void(std::function<void()> &&)> jsCallInvoker,
-                    std::function<void(std::function<void()> &&)> workletCallInvoker);
+  JsiWorkletContext(
+      const std::string &name, jsi::Runtime *jsRuntime,
+      std::function<void(std::function<void()> &&)> jsCallInvoker,
+      std::function<void(std::function<void()> &&)> workletCallInvoker);
 
   /**
    Destructor

--- a/cpp/base/JsiHostObject.cpp
+++ b/cpp/base/JsiHostObject.cpp
@@ -1,5 +1,7 @@
 #include "JsiHostObject.h"
 
+#include <utility>
+
 // To be able to find objects that aren't cleaned up correctly,
 // we can set this value to 1 and debug the constructor/destructor
 #define JSI_DEBUG_ALLOCATIONS 0
@@ -48,11 +50,18 @@ jsi::Value JsiHostObject::get(jsi::Runtime &runtime,
                               const jsi::PropNameID &name) {
   auto nameStr = name.utf8(runtime);
 
-  // Do the happy-paths first
+  // get mapped runtime / function cache
+  auto hostFunctionCache =
+      _hostFunctionCache.find(static_cast<void *>(&runtime));
+  if (hostFunctionCache == _hostFunctionCache.end()) {
+    std::map<std::string, jsi::Function> map;
+    _hostFunctionCache.emplace(static_cast<void *>(&runtime), std::move(map));
+    hostFunctionCache = _hostFunctionCache.find(static_cast<void *>(&runtime));
+  }
 
   // Check function cache
-  auto cachedFunc = _hostFunctionCache.find(nameStr);
-  if (cachedFunc != _hostFunctionCache.end()) {
+  auto cachedFunc = hostFunctionCache->second.find(nameStr);
+  if (cachedFunc != hostFunctionCache->second.end()) {
     return cachedFunc->second.asFunction(runtime);
   }
 
@@ -75,7 +84,7 @@ jsi::Value JsiHostObject::get(jsi::Runtime &runtime,
 
     // Add to cache - it is important to cache the results from the
     // createFromHostFunction function which takes some time.
-    return _hostFunctionCache
+    return hostFunctionCache->second
         .emplace(nameStr, jsi::Function::createFromHostFunction(runtime, name,
                                                                 0, dispatcher))
         .first->second.asFunction(runtime);

--- a/cpp/base/JsiHostObject.h
+++ b/cpp/base/JsiHostObject.h
@@ -195,6 +195,6 @@ protected:
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &runtime) override;
 
 private:
-  std::map<std::string, jsi::Function> _hostFunctionCache;
+  std::map<void *, std::map<std::string, jsi::Function>> _hostFunctionCache;
 };
 } // namespace RNWorklet


### PR DESCRIPTION
Hostfunctions in the HostObject can be created on multiple runtimes - this is something we need to handle in the HostObject.

This commit adds runtime as cache key as well as name.