### PR TITLE
fix: hostobjects are not proxied

### DIFF
--- a/cpp/wrappers/WKTJsiObjectWrapper.h
+++ b/cpp/wrappers/WKTJsiObjectWrapper.h
@@ -161,7 +161,7 @@ protected:
     if (getType() == JsiWrapperType::Object) {
       return getObjectAsProxy(runtime, shared_from_this());
     } else if (getType() == JsiWrapperType::HostObject) {
-      return getObjectAsProxy(runtime, _hostObject);
+      return jsi::Object::createFromHostObject(runtime, _hostObject);
     }
     return JsiWrapper::getAsProxyOrValue(runtime);
   }


### PR DESCRIPTION
Previously host objects where returned as proxied objects when unwrapping. This is not what we want and this has now been fixed.